### PR TITLE
Real entries can now be entered and queried from Career Quiz database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,30 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
+       <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-testing</artifactId>
+      <version>1.9.59</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-labs</artifactId>
+      <version>1.9.59</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>1.9.59</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-tools-sdk</artifactId>
+      <version>1.9.59</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/src/main/java/com/google/sps/data/CareerQuestionAndChoices.java
+++ b/src/main/java/com/google/sps/data/CareerQuestionAndChoices.java
@@ -12,4 +12,12 @@ public final class CareerQuestionAndChoices {
     this.question = question;
     this.choices = choices;
   }  
+
+  public String getQuestion() {
+    return this.question;
+  }
+
+  public List<CareerQuestionChoice> getChoices() {
+    return this.choices;
+  }
 }

--- a/src/main/java/com/google/sps/data/CareerQuestionChoice.java
+++ b/src/main/java/com/google/sps/data/CareerQuestionChoice.java
@@ -13,4 +13,12 @@ public final class CareerQuestionChoice {
     this.choiceText = choiceText;
     this.associatedCareerPath= associatedCareerPath;
   }
+
+  public String getAssociatedCareerPath() {
+    return this.associatedCareerPath;
+  }
+
+  public String getChoiceText() {
+    return this.choiceText;
+  }
 }

--- a/src/main/java/com/google/sps/data/CareerQuestionDatabase.java
+++ b/src/main/java/com/google/sps/data/CareerQuestionDatabase.java
@@ -5,6 +5,8 @@ import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.Key;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -15,10 +17,12 @@ public final class CareerQuestionDatabase {
  
   private DatastoreService datastore;
   private ArrayList<CareerQuestionAndChoices> questionAndChoices;
-  private static final List<CareerQuestionChoice> HARD_CODED_CHOICES = Arrays.asList(
-      new CareerQuestionChoice("choice1", "career1"),
-      new CareerQuestionChoice("choice2", "career2")
-    );
+  private static final String ENTITY_QUERY_STRING = "careerquizquestionandchoices";
+  private static final String QUESTION_QUERY_STRING = "question";
+  private static final String CHOICE_QUERY_STRING = "choice";
+  private static final String CHOICETEXT_QUERY_STRING = "choicetext";
+  private static final String ASSOCIATED_CAREER_PATH_QUERY_STRING = "associatedcareerpath";
+  private static final Query query = new Query(ENTITY_QUERY_STRING);
   
   @Inject
   public CareerQuestionDatabase(DatastoreService datastore) {
@@ -27,13 +31,61 @@ public final class CareerQuestionDatabase {
 
   /* method to return all questions and choices from database as an arraylist */
   public ArrayList<CareerQuestionAndChoices> getQuestionsAndChoices() {
-  // TODO: replace hard coded example Q and Reponse with entities queried from datastore
-    CareerQuestionAndChoices hard_coded_q_and_choice = 
-        new CareerQuestionAndChoices("A question?", HARD_CODED_CHOICES);
-    questionAndChoices = new ArrayList();
-    questionAndChoices.add(hard_coded_q_and_choice);
-  // REPLACE ABOVE
-
-    return questionAndChoices;
+    ArrayList<CareerQuestionAndChoices> careerQuestionAndChoicesList = new ArrayList<CareerQuestionAndChoices>();
+    List<Entity> entities = this.datastore.prepare(this.query).asList(FetchOptions.Builder.withDefaults());
+    for (Entity entity : entities) {
+      CareerQuestionAndChoices careerQuestionAndChoices = this.entityToCareerQuestionAndChoices(entity);
+      careerQuestionAndChoicesList.add(careerQuestionAndChoices);
+    }
+    return careerQuestionAndChoicesList;
   }
+
+  public void putCareerQuestionAndChoicesIntoDatabase(CareerQuestionAndChoices careerQuestionAndChoices) {
+      String question = careerQuestionAndChoices.getQuestion();
+      Entity questionEntity = getQuestionDatastoreEntity(careerQuestionAndChoices);
+      this.datastore.put(questionEntity);
+      for (CareerQuestionChoice choice : careerQuestionAndChoices.getChoices()) {
+        Entity choiceEntity = getChoiceDatastoreEntity(question, choice);
+        this.datastore.put(choiceEntity);
+      }
+  } 
+
+  private CareerQuestionAndChoices entityToCareerQuestionAndChoices(Entity entity) {
+    String question = entity.getProperty(QUESTION_QUERY_STRING).toString();
+    Query associatedChoicesQuery = new Query(question + CHOICETEXT_QUERY_STRING);
+    List<Entity> choiceEntities = this.datastore.prepare(associatedChoicesQuery)
+        .asList(FetchOptions.Builder.withDefaults());
+    List<CareerQuestionChoice> choices = extractChoicesFromChoiceEntities(choiceEntities);
+    return new CareerQuestionAndChoices(question, choices);
+  }
+
+  private List<CareerQuestionChoice> extractChoicesFromChoiceEntities(List<Entity> choiceEntities) {
+    List<CareerQuestionChoice> choices = new ArrayList();
+    for (Entity choiceEntity : choiceEntities) {
+      String choiceText = choiceEntity.getProperty(CHOICETEXT_QUERY_STRING).toString();
+      String associatedCareerPath = choiceEntity.getProperty(ASSOCIATED_CAREER_PATH_QUERY_STRING).toString();
+      CareerQuestionChoice careerQuestionChoice = new CareerQuestionChoice(choiceText, associatedCareerPath);
+      choices.add(careerQuestionChoice);
+    }
+    return choices;
+  }
+
+  private Entity getQuestionDatastoreEntity(CareerQuestionAndChoices careerQuestionAndChoices) {
+    String questionKey = careerQuestionAndChoices.getQuestion();
+    Entity entity = new Entity(ENTITY_QUERY_STRING, questionKey);
+    entity.setProperty(
+        QUESTION_QUERY_STRING, careerQuestionAndChoices.getQuestion());
+    return entity;
+  }
+
+  private Entity getChoiceDatastoreEntity(String associatedQuestion, CareerQuestionChoice careerQuestionChoice) {
+    String choiceEntityType = associatedQuestion + CHOICETEXT_QUERY_STRING;
+    Entity entity = new Entity(choiceEntityType);
+    entity.setProperty(
+        CHOICETEXT_QUERY_STRING, careerQuestionChoice.getChoiceText());
+    entity.setProperty(
+        ASSOCIATED_CAREER_PATH_QUERY_STRING, careerQuestionChoice.getAssociatedCareerPath());
+    return entity;
+  }
+
 }

--- a/src/test/java/com/google/sps/CareerQuizTest.java
+++ b/src/test/java/com/google/sps/CareerQuizTest.java
@@ -9,6 +9,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -21,39 +22,50 @@ import java.util.Arrays;
 import com.google.sps.data.CareerQuestionChoice;
 import com.google.sps.data.CareerQuestionAndChoices;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import static org.mockito.Mockito.when;
 import org.mockito.MockitoAnnotations;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.google.inject.Inject;
 import com.google.inject.Guice;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 
 
 /** Tests the CareerQuiz servlet and its interactions with CareerQuestionDatabase*/
 @RunWith(JUnit4.class)
 public final class CareerQuizTest {
-
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
   @Mock private HttpServletRequest request;
   @Mock private HttpServletResponse response;
-  private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-  @Bind @Spy private CareerQuestionDatabase careerQuestionDatabase = new CareerQuestionDatabase(datastore);
-  @Inject private CareerQuizServlet careerQuizServlet;
+  private CareerQuestionDatabase careerQuestionDatabase;
+  
   private static final List<CareerQuestionChoice> HARD_CODED_CHOICES = Arrays.asList(
     new CareerQuestionChoice("choice1", "career1"),
     new CareerQuestionChoice("choice2", "career2")
   );
-  private static final String DATABASE_OBJECT_JSON = "[{\"question\":\"A question?\",\"choices\":"
+  private static final String DATABASE_OBJECT_JSON = "[{\"question\":\"A question\",\"choices\":"
       + "[{\"choiceText\":\"choice1\",\"associatedCareerPath\":\"career1\"},"
       + "{\"choiceText\":\"choice2\",\"associatedCareerPath\":\"career2\"}]}]";
 
-  @Before
-  public void createInjector() {
+  private void createInjector() {
     Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
     MockitoAnnotations.initMocks(this);
   }
+
+  @Before 
+  public void setUp() {
+    helper.setUp(); // initialize local datastore for testing
+    this.createInjector();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
  
- @Test
+  @Test
   public void testCareerQuizServlet_OutputsJsonDatabaseQuestionAndChoices() throws IOException {
     // mocks the HttpServletResponse, which uses a writer to output JSON response
     StringWriter stringWriter = new StringWriter();
@@ -62,13 +74,12 @@ public final class CareerQuizTest {
     when(this.response.getWriter()).thenReturn(printWriter);
     
     // mocks the result of querying the CareerQuestionDatabase for all the Career Question and choices
-    CareerQuestionAndChoices hard_coded_q_and_choice = 
-        new CareerQuestionAndChoices("A question?", HARD_CODED_CHOICES);
-    ArrayList<CareerQuestionAndChoices> questionAndChoices = new ArrayList();
-    questionAndChoices.add(hard_coded_q_and_choice);
-    when(this.careerQuestionDatabase.getQuestionsAndChoices()).thenReturn(questionAndChoices);
-
-    this.careerQuizServlet.doGet(this.request, this.response);
+    DatastoreService localDatastore = DatastoreServiceFactory.getDatastoreService();
+    careerQuestionDatabase = new CareerQuestionDatabase(localDatastore); 
+    careerQuestionDatabase.putCareerQuestionAndChoicesIntoDatabase(
+        new CareerQuestionAndChoices("A question", HARD_CODED_CHOICES));
+    CareerQuizServlet careerQuizServlet = new CareerQuizServlet(careerQuestionDatabase);
+    careerQuizServlet.doGet(this.request, this.response);
     // checks that the string writer used in servlet mock response contains the database object JSON
     // that matches with the hardcoded CareerQAndChoice given be the mock database
     Assert.assertTrue(stringWriter.toString().contains(DATABASE_OBJECT_JSON));


### PR DESCRIPTION
The CareerQuiz database now supports the insertion and querying of entities. 
In addition, the test has been modified to use a local version of a datastore, local service test helper: https://cloud.google.com/appengine/docs/standard/java/tools/localunittesting/javadoc/com/google/appengine/tools/development/testing/LocalServiceTestHelper.