### PR TITLE
A folder that only admins can access with a database entry page

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<web-app version="3.1" 
+          xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>databaseEntry</web-resource-name>
+            <url-pattern>/admin/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>admin</role-name>
+        </auth-constraint>
+    </security-constraint>
+</web-app>

--- a/src/main/webapp/admin/addStaticData.html
+++ b/src/main/webapp/admin/addStaticData.html
@@ -1,0 +1,21 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+</head>
+
+<body>
+  <h1> Enter in entities to be added to the database here </h1>
+
+  <p> Career Quiz </p>
+  <form action = "/addToDatabase" method = "POST" id = "careerQuizForm">
+    <label>Question:</label><br>
+    <input type = "text" id = "careerquestion"><br>
+    <label>Choices, seperated by semicolons (;)</label><br>
+    <input type = "text" id = "careerchoicetext">
+    <label>Associated career paths, seperated by semicolons (;)</label><br>
+    <input type = "text" id = "careerpath">
+  </form>
+  <button type = "submit" form = "careerQuizForm" name = "careerQuizSubmit" value = "Submit">Submit</button>
+</body>
+</html>


### PR DESCRIPTION
Using the admin API and the documentation described here: https://cloud.google.com/appengine/docs/standard/java/config/webxml#security-auth.

On deployed server, to access admin/ urls you must be logged into your google accounts. Check out this functionality here: http://cs-career-step-2020.appspot.com/admin/addStaticData.html
On a live testing server, you must go to the user auth login page and check "login as admin"