### PR TITLE
Fixed bug: default image works on deploy

### DIFF
--- a/src/main/java/com/google/sps/servlets/ImageHandlerServlet.java
+++ b/src/main/java/com/google/sps/servlets/ImageHandlerServlet.java
@@ -95,16 +95,15 @@ public class ImageHandlerServlet extends HttpServlet {
 
     BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
 
+    // User submitted form without selecting a file, so we have a pointless blobKey. (live server)
+    if (blobInfo.getSize() == 0) {
+      return DEFAULT_PARAMETER;
+    }
+
     // Checks that the file is the right type.
     if (!blobInfo.getContentType().contains(IMAGE_PARAMETER)) {
       blobstoreService.delete(blobKey);
       throw new IllegalArgumentException(ILLEGAL_FILE_TYPE_MESSAGE);
-    }
-
-    // User submitted form without selecting a file, so we have a pointless blobKey. (live server)
-    if (blobInfo.getSize() == 0) {
-      blobstoreService.delete(blobKey);
-      return DEFAULT_PARAMETER;
     }
 
     return blobKey.getKeyString();

--- a/src/test/java/com/google/sps/GetImageServletTest.java
+++ b/src/test/java/com/google/sps/GetImageServletTest.java
@@ -46,6 +46,11 @@ public final class GetImageServletTest {
     return getImageServlet;
   }
 
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
   @Rule public ExpectedException emptyImageRule = ExpectedException.none();
 
   @Test
@@ -68,10 +73,5 @@ public final class GetImageServletTest {
     when(this.response.getWriter()).thenReturn(printWriter);
     emptyImageRule.expect(IllegalArgumentException.class);
     this.getImageServlet.doGet(this.request, this.response);
-  }
-
-  @After
-  public void tearDown() {
-    helper.tearDown();
   }
 }

--- a/src/test/java/com/google/sps/ImageHandlerServletTest.java
+++ b/src/test/java/com/google/sps/ImageHandlerServletTest.java
@@ -63,6 +63,7 @@ public final class ImageHandlerServletTest {
   private final String EXPECTED_OUTPUT_FALSE = "false";
   private final String EXPECTED_OUTPUT_DEFAULT = "default";
   private final String EXPECTED_OUTPUT_EMPTY = "empty";
+  private final String IMAGE_PARAMETER = "image";
   private final String IMAGE_ID_PARAMETER = "imageID";
   private String imageBlobKeyString;
   private ImageHandlerServlet imageHandlerServlet;
@@ -90,6 +91,12 @@ public final class ImageHandlerServletTest {
     this.imageBlobKeyString = "";
     MockitoAnnotations.initMocks(this);
   }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
   // Creating local handle servlet
   public ImageHandlerServlet newImageHandlerServlet() {
     ImageHandlerServlet imageHandlerServlet = new ImageHandlerServlet();
@@ -134,7 +141,7 @@ public final class ImageHandlerServletTest {
   public void doGet_emptyImage() throws IOException {
     StringWriter stringWriter = new StringWriter();
     PrintWriter printWriter = new PrintWriter(stringWriter);
-    when(this.request.getParameter(IMAGE_ID_PARAMETER)).thenReturn(EXPECTED_OUTPUT_DEFAULT);
+    when(this.blobInfo.getSize()).thenReturn(0L);
     when(this.response.getWriter()).thenReturn(printWriter);
     this.imageHandlerServlet.doGet(this.request, this.response);
     String result = stringWriter.toString();
@@ -160,10 +167,5 @@ public final class ImageHandlerServletTest {
     when(this.response.getWriter()).thenReturn(printWriter);
     loggedOutExceptionRule.expect(NullPointerException.class);
     this.imageHandlerServlet.doGet(this.request, this.response);
-  }
-
-  @After
-  public void tearDown() {
-    helper.tearDown();
   }
 }


### PR DESCRIPTION
Because of the order in which the file was being checked, default image redirected as though it was a wrong file type, but now it works as expected.