### PR TITLE
Creating an admin only page to set your own game stage

### DIFF
--- a/src/main/java/com/google/sps/servlets/ImageHandlerServlet.java
+++ b/src/main/java/com/google/sps/servlets/ImageHandlerServlet.java
@@ -40,7 +40,7 @@ public class ImageHandlerServlet extends HttpServlet {
   private static final String IMAGE_ID_PARAMETER = "imageID";
   private static final String IMAGE_PARAMETER = "image";
   private static final String DEFAULT_PARAMETER = "default";
-  private static final String PLAYER_QUERY_PARAMETER = "Player";
+  private static final String PLAYER_QUERY_PARAMETER = "player";
   private static final String UPLOADED_REDIRECT_PARAMETER = "/uploaded.html";
   private static final String LOGIN_REDIRECT_PARAMETER = "/userAuthPage.html";
   private static final String CHARACTER_DESIGN_REDIRECT_PARAMETER = "/characterDesign.html";

--- a/src/main/java/com/google/sps/servlets/SetGameStage.java
+++ b/src/main/java/com/google/sps/servlets/SetGameStage.java
@@ -1,0 +1,61 @@
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.gson.Gson;
+import com.google.sps.data.PlayerDatabase;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Allows admins to set their career path and level for testing */
+@WebServlet("/setGameStage")
+public class SetGameStage extends HttpServlet {
+  private static final String JSON_CONTENT_TYPE = "application/json";
+  private static final String FORM_SUBMIT_PARAMETER = "setGameStageSubmit";
+  private static final String CAREERPATH_PARAMETER = "careerPath";
+  private static final String LEVEL_PARAMETER = "level";
+  private static final String REDIRECTION_URL = "admin/SetGameStage.html";
+  private static Gson gson;
+  private DatastoreService datastore;
+  private UserService userService;
+  private PlayerDatabase playerDatabase;
+
+  @Override
+  public void init() {
+    this.gson = new Gson();
+    this.userService = UserServiceFactory.getUserService();
+    this.datastore = DatastoreServiceFactory.getDatastoreService();
+    this.playerDatabase = new PlayerDatabase(datastore, userService);
+  }
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    if (request.getParameter(FORM_SUBMIT_PARAMETER) != null) {
+      setUserGameStage(request, response);
+    }
+  }
+
+  private void setUserGameStage(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+    String careerPath = request.getParameter(CAREERPATH_PARAMETER);
+    String level = request.getParameter(LEVEL_PARAMETER);
+    String gameStageID = careerPath + level;
+    try {
+      this.playerDatabase.setEntityCurrentPageID(gameStageID);
+      response.sendRedirect(REDIRECTION_URL);
+    } catch (Exception e) {
+      handleNotLoggedInUser(e.getMessage(), response);
+    }
+  }
+
+  private void handleNotLoggedInUser(String message, HttpServletResponse response)
+      throws IOException {
+    response.setContentType(JSON_CONTENT_TYPE);
+    response.getWriter().println(gson.toJson(message));
+  }
+}

--- a/src/main/webapp/admin/SetGameStage.html
+++ b/src/main/webapp/admin/SetGameStage.html
@@ -1,0 +1,30 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+    <script></script>
+</head>
+
+<body>
+  <h1> Set your own career path and level for testing purposes </h1>
+  <p> 
+      Note: only do this after you have created a character in the character design stage, so that your
+      game stage can be properly found and updated. 
+  </p>
+
+  <form action = "/setGameStage" method = "POST" id = "setGameStageForm" name = "setGameStageForm">
+  <label>Career path:</label><br>
+    <input name = "careerPath" list="careerPathOptions" required = "true"><br>
+    <datalist id = "careerPathOptions">
+      <option value = "Software Engineer">
+      <option value = "Web Developer">
+      <option value = "Program Manager">
+      <option value = "Data Scientist">
+    </datalist>
+    <label>Level:</label><br>
+    <input type = "number" name = "level" min = "1" required = "true"><br>
+  </form>
+  <button type = "submit" form = "setGameStageForm" name = "setGameStageSubmit" value = "Submit">Submit</button>
+
+</body>
+</html>

--- a/src/test/java/com/google/sps/SetGameStageTest.java
+++ b/src/test/java/com/google/sps/SetGameStageTest.java
@@ -1,0 +1,197 @@
+package com.google.sps;
+
+import static org.mockito.Mockito.when;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.users.User;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
+import com.google.gson.Gson;
+import com.google.sps.data.Player;
+import com.google.sps.data.PlayerDatabase;
+import com.google.sps.servlets.SetGameStage;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Tests that the SetGameStage servlet correctly updates game stage to be an admin */
+@RunWith(JUnit4.class)
+public final class SetGameStageTest {
+  private static final String AUTH_DOMAIN = "email.com";
+  private static final String CURR_USER_ID = "testid";
+  private static final String USER_ID_KEY_PATH =
+      "com.google.appengine.api.users.UserService.user_id_key";
+  private static Map<String, Object> USER_ID_CONFIG =
+      new HashMap<String, Object>() {
+        {
+          put(USER_ID_KEY_PATH, CURR_USER_ID);
+        }
+      };
+  // creating a test user service, setting current user to be a logged in admin
+  private final LocalUserServiceTestConfig localUserServiceTestConfig =
+      new LocalUserServiceTestConfig().setOAuthUserId(CURR_USER_ID);
+  private final LocalDatastoreServiceTestConfig localDatastoreServiceTestConfig =
+      new LocalDatastoreServiceTestConfig();
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(localUserServiceTestConfig, localDatastoreServiceTestConfig)
+          .setEnvIsAdmin(true)
+          .setEnvAuthDomain(AUTH_DOMAIN)
+          .setEnvEmail(EMAIL)
+          .setEnvIsLoggedIn(true)
+          .setEnvAttributes(USER_ID_CONFIG);
+  private DatastoreService localDatastore;
+  private UserService localUserService;
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  private SetGameStage setGameStage;
+  private PlayerDatabase playerDatabase;
+  private static final String JSON_CONTENT_TYPE = "application/json";
+  private static final String FORM_SUBMIT_PARAMETER = "setGameStageSubmit";
+  private static final String CAREERPATH_PARAMETER = "careerPath";
+  private static final String LEVEL_PARAMETER = "level";
+  private static final String REDIRECTION_URL = "admin/SetGameStage.html";
+  private static final String PROJECT_MANAGER = "Project Manager";
+  private static final String WEB_DEVELOPER = "Web Developer";
+  private static final String SOFTWARE_ENGINEERING = "Software Engineering";
+  private static final String LOGGED_OUT_EXCEPTION =
+      "Player is currently logged out. Cannot process null user.";
+  private static final String LEVEL_1 = "1";
+  private static final String LEVEL_2 = "2";
+  private static final String NAME = "Bob";
+  private static final String EMAIL = "Bob@email.com";
+  private static final Gson gson = new Gson();
+
+  @Before
+  public void setUp() {
+    // initialize local user + datastore service. Current user is admin.
+    helper.setUp();
+    this.localUserService = UserServiceFactory.getUserService();
+    this.localDatastore = DatastoreServiceFactory.getDatastoreService();
+    this.playerDatabase = new PlayerDatabase(this.localDatastore, this.localUserService);
+    this.setGameStage = new SetGameStage();
+    this.setGameStage.init();
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  /** Tests that an admin can update their game state once */
+  @Test
+  public void doPost_AdminInputChangesTheirGameState() throws IOException, Exception {
+    // set user as an arbitrary player
+    User currentUser = this.localUserService.getCurrentUser();
+    String displayName = NAME;
+    String currentGameStageId = PROJECT_MANAGER + LEVEL_2;
+    createCurrentPlayerAndAddToDatabase(
+        playerDatabase, currentUser, displayName, currentGameStageId);
+
+    // mocks user entering in game stage data
+    String careerPathInput = WEB_DEVELOPER;
+    String levelInput = LEVEL_1;
+
+    mockUserGameStageInput(careerPathInput, levelInput);
+
+    this.setGameStage.doPost(this.request, this.response);
+
+    // check that resulting user game stage is the input entered into form
+    String expected = WEB_DEVELOPER + LEVEL_1;
+    String result = this.playerDatabase.getEntityCurrentPageID();
+
+    Assert.assertEquals(expected, result);
+  }
+
+  /** Tests that an admin can update their game state multiple times */
+  @Test
+  public void doPost_AdminInputChangesTheirGameState_MultipleTimes() throws IOException, Exception {
+    // set user as an arbitrary player
+    User currentUser = this.localUserService.getCurrentUser();
+    String displayName = NAME;
+    String currentGameStageId = SOFTWARE_ENGINEERING + LEVEL_1;
+    createCurrentPlayerAndAddToDatabase(
+        playerDatabase, currentUser, displayName, currentGameStageId);
+
+    // mocks user entering in game stage data
+    String careerPathInput1 = WEB_DEVELOPER;
+    String levelInput1 = LEVEL_2;
+
+    mockUserGameStageInput(careerPathInput1, levelInput1);
+
+    this.setGameStage.doPost(this.request, this.response);
+
+    // check that resulting user game stage is the input entered into form
+    String expected1 = WEB_DEVELOPER + LEVEL_2;
+    String result1 = this.playerDatabase.getEntityCurrentPageID();
+
+    Assert.assertEquals(expected1, result1);
+
+    // admin changes game state a second time
+    String careerPathInput2 = PROJECT_MANAGER;
+    String levelInput2 = LEVEL_1;
+
+    mockUserGameStageInput(careerPathInput2, levelInput2);
+
+    this.setGameStage.doPost(this.request, this.response);
+
+    // check that resulting user game stage is the input entered into form
+    String expected2 = PROJECT_MANAGER + LEVEL_1;
+    String result2 = this.playerDatabase.getEntityCurrentPageID();
+
+    Assert.assertEquals(expected2, result2);
+  }
+
+  /** Test that logged out player causes exception message to be written */
+  @Test
+  public void setGameStageWithLoggedOutUser_ExceptionMessageWritten() throws IOException {
+    helper.setEnvIsLoggedIn(false);
+
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+    when(this.response.getWriter()).thenReturn(printWriter);
+
+    // mocks user entering in game stage data
+    String careerPathInput = WEB_DEVELOPER;
+    String levelInput = LEVEL_2;
+
+    mockUserGameStageInput(careerPathInput, levelInput);
+
+    this.setGameStage.doPost(this.request, this.response);
+    String result = stringWriter.toString();
+    Assert.assertTrue(result.contains(LOGGED_OUT_EXCEPTION));
+  }
+
+  private void createCurrentPlayerAndAddToDatabase(
+      PlayerDatabase playerDatabase,
+      User currentUser,
+      String displayName,
+      String currentGameStageId) {
+    Player player = new Player(displayName, currentUser.getEmail(), "blah");
+    player.setID(currentUser.getUserId());
+    player.setCurrentPageID(currentGameStageId);
+    this.playerDatabase.addPlayerToDatabase(player);
+  }
+
+  private void mockUserGameStageInput(String careerPathInput, String levelInput) {
+    when(this.request.getParameter(FORM_SUBMIT_PARAMETER)).thenReturn(FORM_SUBMIT_PARAMETER);
+    when(this.request.getParameter(CAREERPATH_PARAMETER)).thenReturn(careerPathInput);
+    when(this.request.getParameter(LEVEL_PARAMETER)).thenReturn(levelInput);
+  }
+}


### PR DESCRIPTION
Admins can now set their own gamestage so that they can view every page on the site for easy testing. 

Note that you must first login as an admin, then go to character creation stage and create a character in order to update your gamestage.

Login [here](http://cs-career-step-2020.appspot.com/userAuthPage.html).
Create character [here](http://cs-career-step-2020.appspot.com/characterDesign.html).
Set game stage [here](http://cs-career-step-2020.appspot.com/admin/SetGameStage.html). 

To make this work on deployment, fixed a small bug where ImageHandlerServlet was creating player entities with the "Player" name, and playerDatabase was looking up entities using lowercase "player".