### PR TITLE
Promotion quiz now updates the user's game stage

### DIFF
--- a/src/main/java/com/google/sps/data/GameStage.java
+++ b/src/main/java/com/google/sps/data/GameStage.java
@@ -18,6 +18,8 @@ public class GameStage {
    * Game Stages are levels on the gameboard. Each level can be accessed by a player, but only one
    * at a time.
    */
+  private static final String DEFAULT_NEXT_ID_IF_FINAL_STAGE = "finalStage";
+
   private String name;
   /** Represents the title of the game stage */
   private String id;
@@ -54,7 +56,7 @@ public class GameStage {
     this.id = id;
     this.quizKey = quizKey;
     this.isFinalStage = isFinalStage;
-    this.nextStageId = nextStageId;
+    this.nextStageId = isFinalStage ? DEFAULT_NEXT_ID_IF_FINAL_STAGE : nextStageId;
   }
 
   /**

--- a/src/test/java/com/google/sps/PromotionQuizTest.java
+++ b/src/test/java/com/google/sps/PromotionQuizTest.java
@@ -4,11 +4,19 @@ import static org.mockito.Mockito.when;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.users.User;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import com.google.sps.data.GameStage;
+import com.google.sps.data.GameStageDatabase;
+import com.google.sps.data.Player;
+import com.google.sps.data.PlayerDatabase;
 import com.google.sps.data.PromotionMessage;
 import com.google.sps.data.QuestionChoice;
 import com.google.sps.data.QuestionDatabase;
@@ -18,7 +26,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.After;
@@ -33,18 +43,56 @@ import org.mockito.MockitoAnnotations;
 /** Tests the PromotionQuiz servlet and its interactions with QuestionDatabase */
 @RunWith(JUnit4.class)
 public final class PromotionQuizTest {
+  // creating a current user for testing
+  private static final String NAME = "Linda";
+  private static final String EMAIL = "Linda@email.com";
+  private static final String AUTH_DOMAIN = "email.com";
+  private static final String CURRENT_USER_ID = "testidme";
+  private static final String IMAGE_ID = "imageId";
+  private static final String USER_ID_KEY_PATH =
+      "com.google.appengine.api.users.UserService.user_id_key";
+  private static Map<String, Object> USER_ID_CONFIG =
+      new HashMap<String, Object>() {
+        {
+          put(USER_ID_KEY_PATH, CURRENT_USER_ID);
+        }
+      };
+  // creating a test user service, setting current user to be a logged in admin
+  private final LocalUserServiceTestConfig localUserServiceTestConfig =
+      new LocalUserServiceTestConfig().setOAuthUserId(CURRENT_USER_ID);
+  private final LocalDatastoreServiceTestConfig localDatastoreServiceTestConfig =
+      new LocalDatastoreServiceTestConfig();
   private final LocalServiceTestHelper helper =
-      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+      new LocalServiceTestHelper(localUserServiceTestConfig, localDatastoreServiceTestConfig)
+          .setEnvIsAdmin(true)
+          .setEnvAuthDomain(AUTH_DOMAIN)
+          .setEnvEmail(EMAIL)
+          .setEnvIsLoggedIn(true)
+          .setEnvAttributes(USER_ID_CONFIG);
   @Mock private HttpServletRequest request;
   @Mock private HttpServletResponse response;
   private QuestionDatabase questionDatabase;
+  private GameStageDatabase gameStageDatabase;
+  private PlayerDatabase playerDatabase;
   private PromotionQuizServlet promotionQuizServlet;
+  private DatastoreService localDatastore;
+  private UserService localUserService;
   private static final Gson gson = new Gson();
+  private static final String PROJECT_MANAGER = "Project Manager";
+  private static final String PROJECT_MANAGER_NAME = "Project Manager Name";
+  private static final String WEB_DEVELOPER = "Web Developer";
+  private static final String WEB_DEVELOPER_NAME = "Web Developer Name";
+  private static final String TEST_CONTENT = "test content";
+  private static final String LEVEL_1 = "1";
+  private static final String LEVEL_2 = "2";
+  private static final String LEVEL_3 = "3";
   private static final String QUESTION = "A question";
   private static final String CAREER_1 = "career1";
   private static final String CAREER_2 = "career2";
   private static final String CHOICE_1 = "choice1";
   private static final String CHOICE_2 = "choice2";
+  private static final String LOGGED_OUT_EXCEPTION =
+      "Player is currently logged out. Cannot process null user.";
   private static final Boolean ACCEPTABLE = true;
   private static final Boolean NOT_ACCEPTABLE = false;
   private static final String PROMOTION_QUIZ_QUERY = "test1level1";
@@ -52,6 +100,8 @@ public final class PromotionQuizTest {
       "Congratulations, you passed the quiz and were promoted!";
   private static final String NOT_PROMOTED_MESSAGE =
       "You did not pass the quiz. Study the content and try again later";
+  private static final String IS_FINAL_STAGE_MESSAGE =
+      "Congratulations! You reached the final stage! You may no longer be promoted in this path.";
   private static final PromotionMessage IS_PROMOTED =
       new PromotionMessage(/*isPromoted = */ true, PROMOTED_MESSAGE);
   private static final PromotionMessage IS_NOT_PROMOTED =
@@ -71,7 +121,12 @@ public final class PromotionQuizTest {
   public void setUp() {
     helper.setUp(); // initialize local datastore for testing
     MockitoAnnotations.initMocks(this);
+    this.localDatastore = DatastoreServiceFactory.getDatastoreService();
+    this.localUserService = UserServiceFactory.getUserService();
+    this.playerDatabase = new PlayerDatabase(localDatastore, localUserService);
+    this.gameStageDatabase = new GameStageDatabase(localDatastore);
     this.promotionQuizServlet = this.createPromotionQuizServlet();
+    this.promotionQuizServlet.init();
   }
 
   @After
@@ -81,10 +136,7 @@ public final class PromotionQuizTest {
 
   private PromotionQuizServlet createPromotionQuizServlet() {
     DatastoreService localDatastore = DatastoreServiceFactory.getDatastoreService();
-    QuestionDatabase questionDatabase = new QuestionDatabase(localDatastore, PROMOTION_QUIZ_QUERY);
-    questionDatabase.putQuizQuestionsIntoDatabase(new QuizQuestion(QUESTION, HARD_CODED_CHOICES));
     PromotionQuizServlet promotionQuizServlet = new PromotionQuizServlet();
-    promotionQuizServlet.setQuestionDatabase(questionDatabase);
     return promotionQuizServlet;
   }
 
@@ -98,6 +150,25 @@ public final class PromotionQuizTest {
     StringWriter stringWriter = new StringWriter();
     PrintWriter printWriter = new PrintWriter(stringWriter);
     when(this.response.getWriter()).thenReturn(printWriter);
+
+    QuizQuestion quizQuestion = new QuizQuestion(QUESTION, HARD_CODED_CHOICES);
+    String quizQueryString = PROJECT_MANAGER + LEVEL_1;
+    putQuizQuestionIntoDatbase(quizQuestion, quizQueryString);
+
+    User user = this.localUserService.getCurrentUser();
+    String displayName = NAME;
+    String imageId = IMAGE_ID;
+    String gameStageId = PROJECT_MANAGER + LEVEL_1;
+    createCurrentPlayerAndAddToDatabase(user, displayName, imageId, gameStageId);
+
+    String stageName = PROJECT_MANAGER_NAME;
+    String content = TEST_CONTENT;
+    String id = PROJECT_MANAGER + LEVEL_1;
+    String quizKey = id;
+    boolean isLastStage = false;
+    String nextStageId = PROJECT_MANAGER + LEVEL_2;
+    createGameStageAndAddToDatabase(stageName, content, id, quizKey, isLastStage, nextStageId);
+
     // mocks the result of querying the QuestionDatabase for all the Promotion Question and
     // choices
     this.promotionQuizServlet.doGet(this.request, this.response);
@@ -108,32 +179,158 @@ public final class PromotionQuizTest {
     Assert.assertEquals(result, expected);
   }
 
-  /** Tests that the doPost methods responds with being promoted or not */
+  /** If user is on final stage of a path, doGet outputs a message instead of questions */
   @Test
-  public void testPostMethodRespondsWith_Promoted() throws IOException {
-    // mocks user behavior of selecting an accepted choice
-    String choiceJson = gson.toJson(new QuestionChoice(CHOICE_1, CAREER_1, ACCEPTABLE));
-    when(this.request.getParameter(QUESTION)).thenReturn(choiceJson);
+  public void testGetMethodResponds_WithMessageNotQuestion_ifOnFinalStage() throws Exception {
     StringWriter stringWriter = new StringWriter();
     PrintWriter writer = new PrintWriter(stringWriter);
     when(this.response.getWriter()).thenReturn(writer);
-    this.promotionQuizServlet.doPost(this.request, this.response);
-    JsonElement expected = JsonParser.parseString(gson.toJson(IS_PROMOTED));
+
+    User user = this.localUserService.getCurrentUser();
+    String displayName = NAME;
+    String imageId = IMAGE_ID;
+    String gameStageId = WEB_DEVELOPER + LEVEL_3;
+    createCurrentPlayerAndAddToDatabase(user, displayName, imageId, gameStageId);
+
+    String stageName = WEB_DEVELOPER_NAME;
+    String content = TEST_CONTENT;
+    String id = WEB_DEVELOPER + LEVEL_3;
+    String quizKey = id;
+    boolean isLastStage = true;
+    String nextStageId = null;
+    createGameStageAndAddToDatabase(stageName, content, id, quizKey, isLastStage, nextStageId);
+
+    this.promotionQuizServlet.doGet(this.request, this.response);
+
+    JsonElement expected = JsonParser.parseString(gson.toJson(IS_FINAL_STAGE_MESSAGE));
     JsonElement result = JsonParser.parseString(stringWriter.toString());
     Assert.assertEquals(result, expected);
   }
 
+  /** Tests that the doPost methods responds with being promoted or not */
   @Test
-  public void testPostMethodRespondsWith_NotPromoted() throws IOException {
-    // mocks user behavior of selecting a not accepted choice
-    String choiceJson = gson.toJson(new QuestionChoice(CHOICE_1, CAREER_1, NOT_ACCEPTABLE));
-    when(this.request.getParameter(QUESTION)).thenReturn(choiceJson);
+  public void testPostMethodRespondsWith_Promoted() throws IOException, Exception {
     StringWriter stringWriter = new StringWriter();
     PrintWriter writer = new PrintWriter(stringWriter);
     when(this.response.getWriter()).thenReturn(writer);
+
+    QuizQuestion quizQuestion = new QuizQuestion(QUESTION, HARD_CODED_CHOICES);
+    String quizQueryString = WEB_DEVELOPER + LEVEL_2;
+    putQuizQuestionIntoDatbase(quizQuestion, quizQueryString);
+
+    User user = this.localUserService.getCurrentUser();
+    String displayName = NAME;
+    String imageId = IMAGE_ID;
+    String gameStageId = WEB_DEVELOPER + LEVEL_2;
+    createCurrentPlayerAndAddToDatabase(user, displayName, imageId, gameStageId);
+
+    String stageName = WEB_DEVELOPER_NAME;
+    String content = TEST_CONTENT;
+    String id = WEB_DEVELOPER + LEVEL_2;
+    String quizKey = id;
+    boolean isLastStage = false;
+    String nextStageId = WEB_DEVELOPER + LEVEL_3;
+    createGameStageAndAddToDatabase(stageName, content, id, quizKey, isLastStage, nextStageId);
+
+    // mocks user behavior of selecting an accepted choice
+    String choiceJson = gson.toJson(new QuestionChoice(CHOICE_1, CAREER_1, ACCEPTABLE));
+    when(this.request.getParameter(QUESTION)).thenReturn(choiceJson);
+
     this.promotionQuizServlet.doPost(this.request, this.response);
-    JsonElement expected = JsonParser.parseString(gson.toJson(IS_NOT_PROMOTED));
-    JsonElement result = JsonParser.parseString(stringWriter.toString());
-    Assert.assertEquals(result, expected);
+
+    // checks that user promotion message is correct
+    JsonElement expectedMessage = JsonParser.parseString(gson.toJson(IS_PROMOTED));
+    JsonElement resultMessage = JsonParser.parseString(stringWriter.toString());
+    Assert.assertEquals(expectedMessage, resultMessage);
+
+    // checks that user game stage is updated to next level
+    String expectedGameStageId = WEB_DEVELOPER + LEVEL_3;
+    String resultGameStageId = this.playerDatabase.getEntityCurrentPageID();
+    Assert.assertEquals(expectedGameStageId, resultGameStageId);
+  }
+
+  @Test
+  public void testPostMethodRespondsWith_NotPromoted() throws IOException, Exception {
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(this.response.getWriter()).thenReturn(writer);
+
+    QuizQuestion quizQuestion = new QuizQuestion(QUESTION, HARD_CODED_CHOICES);
+    String quizQueryString = PROJECT_MANAGER + LEVEL_2;
+    putQuizQuestionIntoDatbase(quizQuestion, quizQueryString);
+
+    User user = this.localUserService.getCurrentUser();
+    String displayName = NAME;
+    String imageId = IMAGE_ID;
+    String gameStageId = PROJECT_MANAGER + LEVEL_2;
+    createCurrentPlayerAndAddToDatabase(user, displayName, imageId, gameStageId);
+
+    String stageName = PROJECT_MANAGER_NAME;
+    String content = TEST_CONTENT;
+    String id = PROJECT_MANAGER + LEVEL_2;
+    String quizKey = id;
+    boolean isLastStage = false;
+    String nextStageId = PROJECT_MANAGER + LEVEL_3;
+    createGameStageAndAddToDatabase(stageName, content, id, quizKey, isLastStage, nextStageId);
+
+    // mocks user behavior of selecting a not accepted choice
+    String choiceJson = gson.toJson(new QuestionChoice(CHOICE_1, CAREER_1, NOT_ACCEPTABLE));
+    when(this.request.getParameter(QUESTION)).thenReturn(choiceJson);
+
+    this.promotionQuizServlet.doPost(this.request, this.response);
+
+    // checks that user promotion message is correct
+    JsonElement expectedMessage = JsonParser.parseString(gson.toJson(IS_NOT_PROMOTED));
+    JsonElement resultMessage = JsonParser.parseString(stringWriter.toString());
+    Assert.assertEquals(expectedMessage, resultMessage);
+
+    // checks that user game stage is *not* updated to next level
+    String expectedGameStageId = PROJECT_MANAGER + LEVEL_2;
+    String resultGameStageId = this.playerDatabase.getEntityCurrentPageID();
+    Assert.assertEquals(expectedGameStageId, resultGameStageId);
+  }
+
+  /** Test that logged out player causes exception message to be written */
+  @Test
+  public void getPromotionQuizWithLoggedOutUser_ExceptionMessageWritten() throws IOException {
+    helper.setEnvIsLoggedIn(false);
+
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+    when(this.response.getWriter()).thenReturn(printWriter);
+
+    this.promotionQuizServlet.doGet(this.request, this.response);
+
+    String result = stringWriter.toString();
+    Assert.assertTrue(result.contains(LOGGED_OUT_EXCEPTION));
+  }
+
+  private void createCurrentPlayerAndAddToDatabase(
+      User currentUser, String displayName, String imageId, String currentGameStageId) {
+    Player player =
+        new Player(
+            displayName,
+            currentUser.getEmail(),
+            currentUser.getUserId(),
+            imageId,
+            currentGameStageId);
+    this.playerDatabase.addPlayerToDatabase(player);
+  }
+
+  private void createGameStageAndAddToDatabase(
+      String stageName,
+      String content,
+      String id,
+      String quizKey,
+      boolean isLastStage,
+      String nextStageId) {
+    GameStage newGameStage =
+        new GameStage(stageName, content, id, quizKey, isLastStage, nextStageId);
+    this.gameStageDatabase.storeGameStage(newGameStage);
+  }
+
+  private void putQuizQuestionIntoDatbase(QuizQuestion quizQuestion, String quizKey) {
+    this.questionDatabase = new QuestionDatabase(localDatastore, quizKey);
+    questionDatabase.putQuizQuestionsIntoDatabase(quizQuestion);
   }
 }


### PR DESCRIPTION
If the user passes the promotion quiz, their game stage is updated. If the user fails the promotion quiz, their game stage stays the same. 
If the user is on the final stage of a path and they somehow end up on the promotion quiz page, a message is printed to the screen instead of the questions and choices. 

** After talking with Will, filed a bug issue to change the generic Exceptions that the user auth/ player database throws to a more specific custom LoggedOutException. This will be fixed in a later PR.