### PR TITLE
Fix program manager --> project manager name bug

### DIFF
--- a/src/main/webapp/admin/AddStaticData.html
+++ b/src/main/webapp/admin/AddStaticData.html
@@ -32,7 +32,7 @@
     <datalist id = "careerPathOptions">
       <option value = "Software Engineer">
       <option value = "Web Developer">
-      <option value = "Program Manager">
+      <option value = "Project Manager">
       <option value = "Data Scientist">
     </datalist>
     <label>Level:</label><br>
@@ -50,7 +50,7 @@
     <datalist id = "careerPathOptions">
       <option value = "Software Engineer">
       <option value = "Web Developer">
-      <option value = "Program Manager">
+      <option value = "Project Manager">
       <option value = "Data Scientist">
     </datalist>
     <label>Level:</label><br>


### PR DESCRIPTION
Fixed so that career path is "Project Manager", consistent with the name of the career path elsewhere in the game.