### PR TITLE
Adding accessories as an attribute of player

### DIFF
--- a/src/main/java/com/google/sps/data/Player.java
+++ b/src/main/java/com/google/sps/data/Player.java
@@ -1,11 +1,17 @@
 package com.google.sps.data;
 
+import java.util.List;
+
 public class Player {
   private String displayName;
   private String email;
   private String id;
   private String imageID;
   private String currentPageID;
+  private List<String> allAccessoryIDs; // holds all accessories player has earned
+  private String equippedHatID; // accessory id of currently equipped hat
+  private String equippedGlassesID; // accessory id of currently equipped glasses
+  private String equippedCompanionID; // accessory id of currently equipped companion
   /**
    * Experience Points are accumulated by players as they play the game. The amount of points a
    * player has determines when they can try for promotion, when a special event may occur, or when
@@ -31,8 +37,10 @@ public class Player {
       String id,
       String imageID,
       String currentPageID,
+      List<String> allAccessoryIDs,
       int experiencePoints) {
     this(displayName, email, id, imageID, currentPageID);
+    this.allAccessoryIDs = allAccessoryIDs;
     this.experiencePoints = experiencePoints;
   }
 
@@ -58,6 +66,34 @@ public class Player {
 
   public int getExperiencePoints() {
     return experiencePoints;
+  }
+
+  public List<String> getAllAccessoryIDs() {
+    return this.allAccessoryIDs;
+  }
+
+  public String getEquippedHatID() {
+    return this.equippedHatID;
+  }
+
+  public String getEquippedGlassesID() {
+    return this.equippedGlassesID;
+  }
+
+  public String getEquippedCompanionID() {
+    return this.equippedCompanionID;
+  }
+
+  public void setEquippedCompanionID(String companionID) {
+    this.equippedCompanionID = companionID;
+  }
+
+  public void setEquippedHatID(String hatID) {
+    this.equippedHatID = hatID;
+  }
+
+  public void setEquippedGlassesID(String glassesID) {
+    this.equippedGlassesID = glassesID;
   }
 
   public void setDisplayName(String displayName) {

--- a/src/main/java/com/google/sps/data/PlayerDatabase.java
+++ b/src/main/java/com/google/sps/data/PlayerDatabase.java
@@ -21,6 +21,11 @@ public class PlayerDatabase {
   private static final String IMAGE_ID_QUERY_STRING = "imageID";
   private static final String CURRENT_PAGE_ID_QUERY_STRING = "currentPageID";
   private static final String EXPERIENCE_QUERY_STRING = "experience";
+  private static final String ALL_ACCESSORIES_QUERY_STRING = "allAccesories";
+  private static final String EQUIPPED_HAT_QUERY_STRING = "equippedHat";
+  private static final String EQUIPPED_GLASSES_QUERY_STRING = "equippedGlasses";
+  private static final String EQUIPPED_COMPANION_QUERY_STRING = "equippedCompanion";
+  private static final String NONE_EQUIPPED = "noneEquipped";
   private static final Query query = new Query(ENTITY_QUERY_STRING);
   private User user;
   private String userEmail = UserServiceFactory.getUserService().getCurrentUser().getEmail();
@@ -47,18 +52,32 @@ public class PlayerDatabase {
     datastore.put(entity);
   }
 
+  private static String defaultIfNoneEquipped(String accessory) {
+    return accessory == null ? NONE_EQUIPPED : accessory;
+  }
+
   public static Entity createEntityFromPlayer(Player player) {
     String displayName = player.getDisplayName();
     String id = player.getID();
     String email = player.getEmail();
     String imageID = player.getImageID();
     String currentPageID = player.getCurrentPageID();
+    String equippedHatID = player.getEquippedHatID();
+    String equippedGlassesID = player.getEquippedGlassesID();
+    String equippedCompanionID = player.getEquippedCompanionID();
+    List<String> allAccessoryIDs = player.getAllAccessoryIDs();
+
     Entity entity = new Entity(ENTITY_QUERY_STRING);
+
     entity.setProperty(DISPLAY_NAME_QUERY_STRING, displayName);
     entity.setProperty(EMAIL_QUERY_STRING, email);
     entity.setProperty(ID_QUERY_STRING, id);
     entity.setProperty(IMAGE_ID_QUERY_STRING, imageID);
     entity.setProperty(CURRENT_PAGE_ID_QUERY_STRING, currentPageID);
+    entity.setProperty(EQUIPPED_HAT_QUERY_STRING, defaultIfNoneEquipped(equippedHatID));
+    entity.setProperty(EQUIPPED_GLASSES_QUERY_STRING, defaultIfNoneEquipped(equippedGlassesID));
+    entity.setProperty(EQUIPPED_COMPANION_QUERY_STRING, defaultIfNoneEquipped(equippedCompanionID));
+    entity.setProperty(ALL_ACCESSORIES_QUERY_STRING, allAccessoryIDs);
     return entity;
   }
 
@@ -106,6 +125,33 @@ public class PlayerDatabase {
     return Integer.parseInt(experienceString);
   }
 
+  public List<String> getEntityAllAccessoryIDs() throws LoggedOutException {
+    // supress warnings/ casting used in GAE documentation to get multivalued attributes:
+    // https://cloud.google.com/appengine/docs/standard/java/datastore/entity-property-reference
+    @SuppressWarnings("unchecked")
+    List<String> allAccessoryIDs =
+        (List<String>) getCurrentPlayerEntity().getProperty(ALL_ACCESSORIES_QUERY_STRING);
+    return allAccessoryIDs;
+  }
+
+  public String getEntityEquippedHatID() throws LoggedOutException {
+    String equippedHatID =
+        getCurrentPlayerEntity().getProperty(EQUIPPED_HAT_QUERY_STRING).toString();
+    return equippedHatID;
+  }
+
+  public String getEntityEquippedGlassesID() throws LoggedOutException {
+    String equippedGlassesID =
+        getCurrentPlayerEntity().getProperty(EQUIPPED_GLASSES_QUERY_STRING).toString();
+    return equippedGlassesID;
+  }
+
+  public String getEntityEquippedCompanionID() throws LoggedOutException {
+    String equippedCompanionID =
+        getCurrentPlayerEntity().getProperty(EQUIPPED_COMPANION_QUERY_STRING).toString();
+    return equippedCompanionID;
+  }
+
   // get displayname
   public String getEntityDisplayName() throws LoggedOutException {
     String displayName = getCurrentPlayerEntity().getProperty(DISPLAY_NAME_QUERY_STRING).toString();
@@ -129,6 +175,18 @@ public class PlayerDatabase {
 
   public void setEntityExperience(int experience) throws LoggedOutException {
     setPlayerProperty(EXPERIENCE_QUERY_STRING, Integer.toString(experience));
+  }
+
+  public void setEntityEquippedHatID(String equippedHatID) throws LoggedOutException {
+    setPlayerProperty(EQUIPPED_HAT_QUERY_STRING, defaultIfNoneEquipped(equippedHatID));
+  }
+
+  public void setEntityEquippedGlassesID(String equippedGlassesID) throws LoggedOutException {
+    setPlayerProperty(EQUIPPED_GLASSES_QUERY_STRING, defaultIfNoneEquipped(equippedGlassesID));
+  }
+
+  public void setEntityEquippedCompanionID(String equippedCompanionID) throws LoggedOutException {
+    setPlayerProperty(EQUIPPED_COMPANION_QUERY_STRING, defaultIfNoneEquipped(equippedCompanionID));
   }
 
   // set displayname


### PR DESCRIPTION
A player now holds a list of strings, which is the ids of the accessories that they have earned and can potentially equip.
A player also has an attribute for the id each of the three currently equipped accessories. If none are equipped, the id is instead a default value.