### PR TITLE
Bug fix: all apostrophes now display correctly

### DIFF
--- a/src/main/java/com/google/sps/servlets/GetGameDialogue.java
+++ b/src/main/java/com/google/sps/servlets/GetGameDialogue.java
@@ -44,7 +44,7 @@ public final class GetGameDialogue extends HttpServlet {
     try {
       GameStage currentGameStage =
           gameStageDatabase.getGameStage(playerDatabase.getEntityCurrentPageID());
-      String dialogue = gson.toJson(currentGameStage.getContent());
+      String dialogue = currentGameStage.getContent();
       String id = currentGameStage.getID();
       String level = id.substring(id.length() - 1);
       // Checks that the Level String can be parsed to an int without throwing an exception.

--- a/src/main/webapp/gameHelper.js
+++ b/src/main/webapp/gameHelper.js
@@ -49,8 +49,6 @@ function addDialogueToDom(textResponse) {
   
   const quoteContainer = document.getElementById('dialogue-container');
   var dialogue = responseArray[1];
-  // Substring gets rid of the surrounding quotation marks in the string.
-  dialogue = dialogue.substring(1, dialogue.length - 1);
   dialogueArray = dialogue.split(";");
   dialogueRegex = 0;
   splitSentenceToWords()


### PR DESCRIPTION
Originally, apostrophes were showing up as "?" in our application. I got rid of the gson.ToJson conversion and made sure to stop trimming off the quotation marks in the js file to fix the text display. 