### PR TITLE
Fix player state (#218)

### DIFF
--- a/src/main/java/com/google/sps/data/PlayerDatabase.java
+++ b/src/main/java/com/google/sps/data/PlayerDatabase.java
@@ -39,16 +39,20 @@ public class PlayerDatabase {
     return players;
   }
 
-  public PlayerDatabase(DatastoreService datastore) {
+  public PlayerDatabase(DatastoreService datastore) throws LoggedOutException {
     this(datastore, UserServiceFactory.getUserService());
   }
 
-  public PlayerDatabase(DatastoreService datastore, UserService userService) {
+  public PlayerDatabase(DatastoreService datastore, UserService userService)
+      throws LoggedOutException {
+    this.isLoggedIn = userService.isUserLoggedIn();
+    if (!this.isLoggedIn) {
+      throw new LoggedOutException();
+    }
     this.datastore = datastore;
     this.user = userService.getCurrentUser();
     this.userEmail = this.user.getEmail();
     this.userID = this.user.getUserId();
-    this.isLoggedIn = userService.isUserLoggedIn();
   }
 
   public static void addPlayerToDatabase(Player player) {

--- a/src/main/java/com/google/sps/servlets/DeleteUserServlet.java
+++ b/src/main/java/com/google/sps/servlets/DeleteUserServlet.java
@@ -25,23 +25,22 @@ public class DeleteUserServlet extends HttpServlet {
   private static final String JSON_CONTENT_TYPE = "application/json";
   private static final String PLAYER_PARAMETER = "player";
   private static final String ID_PARAMETER = "name";
-  private static Gson gson;
-  private DatastoreService datastore;
-  private UserService userService;
-  private PlayerDatabase playerDatabase;
+  private static Gson gson = new Gson();
+  DatastoreService datastore;
+  UserService userService;
+  PlayerDatabase playerDatabase;
 
-  @Override
-  public void init() {
-    this.gson = new Gson();
-    this.userService = UserServiceFactory.getUserService();
+  private void updateService() throws LoggedOutException {
     this.datastore = DatastoreServiceFactory.getDatastoreService();
+    this.userService = UserServiceFactory.getUserService();
     this.playerDatabase = new PlayerDatabase(datastore, userService);
   }
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     try {
-      Entity currentPlayer = playerDatabase.getCurrentPlayerEntity();
+      updateService();
+      Entity currentPlayer = this.playerDatabase.getCurrentPlayerEntity();
       Key playerEntityKey = currentPlayer.getKey();
       datastore.delete(playerEntityKey);
       deletePlayerFromPlayerDatabase(response);
@@ -53,10 +52,10 @@ public class DeleteUserServlet extends HttpServlet {
   }
 
   public void deletePlayerFromPlayerDatabase(HttpServletResponse response) throws IOException {
-    List<Player> players = playerDatabase.getPlayers();
+    List<Player> players = this.playerDatabase.getPlayers();
     List<Player> playersToDelete = new ArrayList<>();
     Player playerToDelete = null;
-    String email = userService.getCurrentUser().getEmail().toString();
+    String email = this.userService.getCurrentUser().getEmail().toString();
     for (Player player : players) {
       if (player.getEmail().equals(email)) {
         playersToDelete.add(player);

--- a/src/main/java/com/google/sps/servlets/GetEquippedAccessories.java
+++ b/src/main/java/com/google/sps/servlets/GetEquippedAccessories.java
@@ -32,17 +32,20 @@ public class GetEquippedAccessories extends HttpServlet {
       "Something went wrong. The accessory was not found in the database.";
   private static Gson gson;
   private static JsonParser jsonParser;
-  private DatastoreService datastore;
-  private UserService userService;
-  private PlayerDatabase playerDatabase;
-  private AccessoryDatabase accessoryDatabase;
+  DatastoreService datastore;
+  UserService userService;
+  AccessoryDatabase accessoryDatabase;
+  PlayerDatabase playerDatabase;
 
   @Override
   public void init() {
     this.gson = new Gson();
     this.jsonParser = new JsonParser();
-    this.userService = UserServiceFactory.getUserService();
+  }
+
+  private void updateService() throws LoggedOutException {
     this.datastore = DatastoreServiceFactory.getDatastoreService();
+    this.userService = UserServiceFactory.getUserService();
     this.playerDatabase = new PlayerDatabase(datastore, userService);
     this.accessoryDatabase = new AccessoryDatabase(datastore);
   }
@@ -51,6 +54,8 @@ public class GetEquippedAccessories extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     try {
+      updateService();
+
       String equippedHatID = this.playerDatabase.getEntityEquippedHatID();
       String equippedGlassesID = this.playerDatabase.getEntityEquippedGlassesID();
       String equippedCompanionID = this.playerDatabase.getEntityEquippedCompanionID();
@@ -93,6 +98,8 @@ public class GetEquippedAccessories extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     try {
+      updateService();
+
       String equippedHatID = request.getParameter(EQUIPPED_HAT);
       String equippedGlassesID = request.getParameter(EQUIPPED_GLASSES);
       String equippedCompanionID = request.getParameter(EQUIPPED_COMPANION);

--- a/src/main/java/com/google/sps/servlets/GetGameDialogue.java
+++ b/src/main/java/com/google/sps/servlets/GetGameDialogue.java
@@ -37,16 +37,24 @@ public final class GetGameDialogue extends HttpServlet {
   private static final String LOGGED_OUT_EXCEPTION = "It appears that you have not logged in";
   private static final String NUMBER_FORMAT_EXCEPTION = "Could not parse integer from level id";
   private static final Gson gson = new Gson();
-  private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-  private UserService userService = UserServiceFactory.getUserService();
-  private PlayerDatabase playerDatabase = new PlayerDatabase(datastore, userService);
-  private GameStageDatabase gameStageDatabase = new GameStageDatabase(datastore);
+  DatastoreService datastore;
+  UserService userService;
+  PlayerDatabase playerDatabase;
+  GameStageDatabase gameStageDatabase;
+
+  private void updateService() throws LoggedOutException {
+    this.datastore = DatastoreServiceFactory.getDatastoreService();
+    this.userService = UserServiceFactory.getUserService();
+    this.playerDatabase = new PlayerDatabase(datastore, userService);
+    this.gameStageDatabase = new GameStageDatabase(datastore);
+  }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     try {
+      updateService();
       GameStage currentGameStage =
-          gameStageDatabase.getGameStage(playerDatabase.getEntityCurrentPageID());
+          this.gameStageDatabase.getGameStage(this.playerDatabase.getEntityCurrentPageID());
       String dialogue = currentGameStage.getContent();
       String id = currentGameStage.getID();
       String level = id.substring(id.length() - 1);

--- a/src/main/java/com/google/sps/servlets/GetPlayerAccessories.java
+++ b/src/main/java/com/google/sps/servlets/GetPlayerAccessories.java
@@ -25,17 +25,16 @@ public class GetPlayerAccessories extends HttpServlet {
   private static final String HTML_CONTENT_TYPE = "text/html";
   private static final String LOGGED_OUT_EXCEPTION =
       "Player is currently logged out. Cannot process null user.";
-  private static Gson gson;
-  private DatastoreService datastore;
-  private UserService userService;
-  private PlayerDatabase playerDatabase;
-  private AccessoryDatabase accessoryDatabase;
+  private static Gson gson = new Gson();
 
-  @Override
-  public void init() {
-    this.gson = new Gson();
-    this.userService = UserServiceFactory.getUserService();
+  DatastoreService datastore;
+  UserService userService;
+  AccessoryDatabase accessoryDatabase;
+  PlayerDatabase playerDatabase;
+
+  private void updateService() throws LoggedOutException {
     this.datastore = DatastoreServiceFactory.getDatastoreService();
+    this.userService = UserServiceFactory.getUserService();
     this.playerDatabase = new PlayerDatabase(datastore, userService);
     this.accessoryDatabase = new AccessoryDatabase(datastore);
   }
@@ -43,6 +42,7 @@ public class GetPlayerAccessories extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     try {
+      updateService();
       List<String> accessoryIDs = this.playerDatabase.getEntityAllAccessoryIDs();
       List<Accessory> accessories = new ArrayList();
       for (String id : accessoryIDs) {

--- a/src/main/java/com/google/sps/servlets/GetPlayerNameFromDatabase.java
+++ b/src/main/java/com/google/sps/servlets/GetPlayerNameFromDatabase.java
@@ -35,13 +35,20 @@ public final class GetPlayerNameFromDatabase extends HttpServlet {
   private static final String LOGGED_OUT_EXCEPTION =
       "Player is currently logged out. Cannot process null user.";
   private static final Gson gson = new Gson();
-  private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-  private UserService userService = UserServiceFactory.getUserService();
-  private PlayerDatabase playerDatabase = new PlayerDatabase(datastore, userService);
+  DatastoreService datastore;
+  UserService userService;
+  PlayerDatabase playerDatabase;
+
+  private void updateService() throws LoggedOutException {
+    this.datastore = DatastoreServiceFactory.getDatastoreService();
+    this.userService = UserServiceFactory.getUserService();
+    this.playerDatabase = new PlayerDatabase(datastore, userService);
+  }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     try {
+      updateService();
       String playerName = playerDatabase.getEntityDisplayName();
       response.setContentType(TEXT_TO_HTML);
       response.getWriter().print(playerName);

--- a/src/main/java/com/google/sps/servlets/InitializeGameStage.java
+++ b/src/main/java/com/google/sps/servlets/InitializeGameStage.java
@@ -20,36 +20,35 @@ public class InitializeGameStage extends HttpServlet {
   private static final String FORM_SUBMIT_PARAMETER = "pathSubmit";
   private static final String REDIRECTION_URL = "gameStage.html";
   private static final String LEVEL_1 = "1";
-  private static Gson gson;
-  private DatastoreService datastore;
-  private UserService userService;
-  private PlayerDatabase playerDatabase;
+  private static Gson gson = new Gson();
+  DatastoreService datastore;
+  UserService userService;
+  PlayerDatabase playerDatabase;
 
-  @Override
-  public void init() {
-    this.gson = new Gson();
-    this.userService = UserServiceFactory.getUserService();
+  private void updateService() throws LoggedOutException {
     this.datastore = DatastoreServiceFactory.getDatastoreService();
+    this.userService = UserServiceFactory.getUserService();
     this.playerDatabase = new PlayerDatabase(datastore, userService);
   }
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    if (request.getParameter(FORM_SUBMIT_PARAMETER) != null) {
-      setUserGameStage(request, response);
+    try {
+      updateService();
+      if (request.getParameter(FORM_SUBMIT_PARAMETER) != null) {
+        setUserGameStage(request, response);
+      }
+    } catch (LoggedOutException e) {
+      handleNotLoggedInUser(e.getMessage(), response);
     }
   }
 
   private void setUserGameStage(HttpServletRequest request, HttpServletResponse response)
-      throws IOException {
+      throws IOException, LoggedOutException {
     String careerPath = request.getParameter(FORM_SUBMIT_PARAMETER);
     String gameStageID = careerPath + LEVEL_1;
-    try {
-      this.playerDatabase.setEntityCurrentPageID(gameStageID);
-      response.sendRedirect(REDIRECTION_URL);
-    } catch (LoggedOutException e) {
-      handleNotLoggedInUser(e.getMessage(), response);
-    }
+    this.playerDatabase.setEntityCurrentPageID(gameStageID);
+    response.sendRedirect(REDIRECTION_URL);
   }
 
   private void handleNotLoggedInUser(String message, HttpServletResponse response)

--- a/src/main/java/com/google/sps/servlets/IsFinalStage.java
+++ b/src/main/java/com/google/sps/servlets/IsFinalStage.java
@@ -32,15 +32,14 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/isFinalStage")
 public final class IsFinalStage extends HttpServlet {
   private static final String HTML_CONTENT_TYPE = "text/html;";
-  private DatastoreService datastore;
-  private UserService userService;
-  private PlayerDatabase playerDatabase;
-  private GameStageDatabase gameStageDatabase;
+  DatastoreService datastore;
+  UserService userService;
+  PlayerDatabase playerDatabase;
+  GameStageDatabase gameStageDatabase;
 
-  @Override
-  public void init() {
-    this.userService = UserServiceFactory.getUserService();
+  private void updateService() throws LoggedOutException {
     this.datastore = DatastoreServiceFactory.getDatastoreService();
+    this.userService = UserServiceFactory.getUserService();
     this.playerDatabase = new PlayerDatabase(datastore, userService);
     this.gameStageDatabase = new GameStageDatabase(datastore);
   }
@@ -48,6 +47,7 @@ public final class IsFinalStage extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     try {
+      updateService();
       GameStage currentGameStage =
           this.gameStageDatabase.getGameStage(this.playerDatabase.getEntityCurrentPageID());
       boolean isFinalStage = currentGameStage.isFinalStage();

--- a/src/main/java/com/google/sps/servlets/SetGameStage.java
+++ b/src/main/java/com/google/sps/servlets/SetGameStage.java
@@ -21,16 +21,14 @@ public class SetGameStage extends HttpServlet {
   private static final String CAREERPATH_PARAMETER = "careerPath";
   private static final String LEVEL_PARAMETER = "level";
   private static final String REDIRECTION_URL = "admin/SetGameStage.html";
-  private static Gson gson;
-  private DatastoreService datastore;
-  private UserService userService;
-  private PlayerDatabase playerDatabase;
+  private static Gson gson = new Gson();
+  DatastoreService datastore;
+  UserService userService;
+  PlayerDatabase playerDatabase;
 
-  @Override
-  public void init() {
-    this.gson = new Gson();
-    this.userService = UserServiceFactory.getUserService();
+  private void updateService() throws LoggedOutException {
     this.datastore = DatastoreServiceFactory.getDatastoreService();
+    this.userService = UserServiceFactory.getUserService();
     this.playerDatabase = new PlayerDatabase(datastore, userService);
   }
 
@@ -43,10 +41,11 @@ public class SetGameStage extends HttpServlet {
 
   private void setUserGameStage(HttpServletRequest request, HttpServletResponse response)
       throws IOException {
-    String careerPath = request.getParameter(CAREERPATH_PARAMETER);
-    String level = request.getParameter(LEVEL_PARAMETER);
-    String gameStageID = careerPath + level;
     try {
+      updateService();
+      String careerPath = request.getParameter(CAREERPATH_PARAMETER);
+      String level = request.getParameter(LEVEL_PARAMETER);
+      String gameStageID = careerPath + level;
       this.playerDatabase.setEntityCurrentPageID(gameStageID);
       response.sendRedirect(REDIRECTION_URL);
     } catch (LoggedOutException e) {

--- a/src/test/java/com/google/sps/DeleteUserServletTest.java
+++ b/src/test/java/com/google/sps/DeleteUserServletTest.java
@@ -69,13 +69,12 @@ public final class DeleteUserServletTest {
   @Mock private HttpServletResponse response;
 
   @Before
-  public void setUp() {
+  public void setUp() throws LoggedOutException {
     // initialize local user + datastore service.
     helper.setUp();
     this.localUserService = UserServiceFactory.getUserService();
     this.localDatastore = DatastoreServiceFactory.getDatastoreService();
     this.deleteUserServlet = new DeleteUserServlet();
-    this.deleteUserServlet.init();
     this.playerDatabase = new PlayerDatabase(this.localDatastore, this.localUserService);
     MockitoAnnotations.initMocks(this);
   }

--- a/src/test/java/com/google/sps/EarnRandomAccessoryTest.java
+++ b/src/test/java/com/google/sps/EarnRandomAccessoryTest.java
@@ -107,7 +107,7 @@ public final class EarnRandomAccessoryTest {
   private Random randomGenerator;
 
   @Before
-  public void setUp() {
+  public void setUp() throws LoggedOutException {
     helper.setUp(); // initialize local datastore for testing
     MockitoAnnotations.initMocks(this);
     this.localDatastore = DatastoreServiceFactory.getDatastoreService();
@@ -117,8 +117,8 @@ public final class EarnRandomAccessoryTest {
     this.randomGenerator = new Random();
     this.randomGenerator.setSeed(RANDOM_NUMBER_SEED);
     this.earnRandomAccessory = new EarnRandomAccessory();
-    this.earnRandomAccessory.init();
     this.earnRandomAccessory.setRandomNumberGenerator(this.randomGenerator);
+    this.earnRandomAccessory.init();
   }
 
   @After

--- a/src/test/java/com/google/sps/ExperienceServletTest.java
+++ b/src/test/java/com/google/sps/ExperienceServletTest.java
@@ -78,12 +78,11 @@ public final class ExperienceServletTest {
   @Mock private HttpServletResponse response;
 
   @Before
-  public void setUp() {
+  public void setUp() throws LoggedOutException {
     helper.setUp();
     this.localUserService = UserServiceFactory.getUserService();
     this.localDatastore = DatastoreServiceFactory.getDatastoreService();
     this.experienceServlet = new ExperienceServlet();
-    this.experienceServlet.init();
     this.experience = 12;
     this.playerDatabase = new PlayerDatabase(this.localDatastore, this.localUserService);
     MockitoAnnotations.initMocks(this);

--- a/src/test/java/com/google/sps/GetEquippedAccessoriesTest.java
+++ b/src/test/java/com/google/sps/GetEquippedAccessoriesTest.java
@@ -101,7 +101,7 @@ public final class GetEquippedAccessoriesTest {
       "Something went wrong. The accessory was not found in the database.";
 
   @Before
-  public void setUp() {
+  public void setUp() throws LoggedOutException {
     helper.setUp(); // initialize local datastore for testing
     MockitoAnnotations.initMocks(this);
     this.localDatastore = DatastoreServiceFactory.getDatastoreService();

--- a/src/test/java/com/google/sps/GetPlayerAccessoriesTest.java
+++ b/src/test/java/com/google/sps/GetPlayerAccessoriesTest.java
@@ -16,6 +16,7 @@ import com.google.gson.JsonParser;
 import com.google.sps.data.Accessory;
 import com.google.sps.data.Accessory.Type;
 import com.google.sps.data.AccessoryDatabase;
+import com.google.sps.data.LoggedOutException;
 import com.google.sps.data.Player;
 import com.google.sps.data.PlayerDatabase;
 import com.google.sps.servlets.GetPlayerAccessories;
@@ -99,7 +100,7 @@ public final class GetPlayerAccessoriesTest {
   private static final Gson gson = new Gson();
 
   @Before
-  public void setUp() {
+  public void setUp() throws LoggedOutException {
     helper.setUp(); // initialize local datastore for testing
     MockitoAnnotations.initMocks(this);
     this.localDatastore = DatastoreServiceFactory.getDatastoreService();
@@ -107,7 +108,6 @@ public final class GetPlayerAccessoriesTest {
     this.accessoryDatabase = new AccessoryDatabase(localDatastore);
     this.playerDatabase = new PlayerDatabase(localDatastore, localUserService);
     this.getPlayerAccessories = new GetPlayerAccessories();
-    this.getPlayerAccessories.init();
   }
 
   @After

--- a/src/test/java/com/google/sps/GetPlayerNameFromDatabaseTest.java
+++ b/src/test/java/com/google/sps/GetPlayerNameFromDatabaseTest.java
@@ -20,7 +20,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.After;
@@ -77,13 +76,12 @@ public final class GetPlayerNameFromDatabaseTest {
   @Rule public ExpectedException canNotInitialize = ExpectedException.none();
 
   @Before
-  public void setUp() throws ServletException {
+  public void setUp() throws LoggedOutException {
     helper.setUp();
     this.localUserService = UserServiceFactory.getUserService();
     this.localDatastore = DatastoreServiceFactory.getDatastoreService();
     this.playerDatabase = new PlayerDatabase(this.localDatastore, this.localUserService);
     this.getPlayerNameServlet = new GetPlayerNameFromDatabase();
-    this.getPlayerNameServlet.init();
     MockitoAnnotations.initMocks(this);
   }
 

--- a/src/test/java/com/google/sps/ImageHandlerServletTest.java
+++ b/src/test/java/com/google/sps/ImageHandlerServletTest.java
@@ -13,6 +13,7 @@ import com.google.appengine.api.users.UserServiceFactory;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
+import com.google.sps.data.LoggedOutException;
 import com.google.sps.data.Player;
 import com.google.sps.data.PlayerDatabase;
 import com.google.sps.servlets.ImageHandlerServlet;
@@ -38,6 +39,7 @@ import org.mockito.MockitoAnnotations;
 // They create accurate links.
 @RunWith(JUnit4.class)
 public final class ImageHandlerServletTest {
+  private static final String HANDLE_LOGGED_OUT_USER = "false\nempty\nnull\n";
   private final String EMAIL = "email";
   private final String AUTH_DOMAIN = "email.com";
   private final String CURR_USER_ID = "testid";
@@ -79,11 +81,10 @@ public final class ImageHandlerServletTest {
   @Mock private BlobInfo blobInfo;
 
   @Before
-  public void setUp() {
+  public void setUp() throws LoggedOutException {
     helper.setUp();
     this.userService = UserServiceFactory.getUserService();
     this.imageHandlerServlet = this.newImageHandlerServlet();
-    this.imageHandlerServlet.init();
     this.datastore = DatastoreServiceFactory.getDatastoreService();
     this.playerDatabase = new PlayerDatabase(datastore, userService);
     this.player =
@@ -161,12 +162,13 @@ public final class ImageHandlerServletTest {
   }
 
   @Test
-  public void doGet_whileLoggedOut_throwsNullPointerException() throws IOException {
+  public void doGet_handleLoggedOutUser() throws IOException {
     helper.setEnvIsLoggedIn(false);
     StringWriter stringWriter = new StringWriter();
     PrintWriter printWriter = new PrintWriter(stringWriter);
     when(this.response.getWriter()).thenReturn(printWriter);
-    loggedOutExceptionRule.expect(NullPointerException.class);
     this.imageHandlerServlet.doGet(this.request, this.response);
+    String result = stringWriter.toString();
+    Assert.assertEquals(result, HANDLE_LOGGED_OUT_USER);
   }
 }

--- a/src/test/java/com/google/sps/InitializeGameStageTest.java
+++ b/src/test/java/com/google/sps/InitializeGameStageTest.java
@@ -80,14 +80,13 @@ public final class InitializeGameStageTest {
   private static final Gson gson = new Gson();
 
   @Before
-  public void setUp() {
+  public void setUp() throws LoggedOutException {
     // initialize local user + datastore service. Current user is admin.
     helper.setUp();
     this.localUserService = UserServiceFactory.getUserService();
     this.localDatastore = DatastoreServiceFactory.getDatastoreService();
     this.playerDatabase = new PlayerDatabase(this.localDatastore, this.localUserService);
     this.initializeGameStage = new InitializeGameStage();
-    this.initializeGameStage.init();
     MockitoAnnotations.initMocks(this);
   }
 
@@ -152,7 +151,6 @@ public final class InitializeGameStageTest {
     when(this.request.getParameter(FORM_SUBMIT_PARAMETER)).thenReturn(WEB_DEVELOPER);
     this.initializeGameStage.doPost(this.request, this.response);
 
-    this.initializeGameStage.doPost(this.request, this.response);
     String result = stringWriter.toString();
     Assert.assertTrue(result.contains(LOGGED_OUT_EXCEPTION));
   }

--- a/src/test/java/com/google/sps/IsFinalStageTest.java
+++ b/src/test/java/com/google/sps/IsFinalStageTest.java
@@ -83,7 +83,7 @@ public final class IsFinalStageTest {
   private static final String IS_NOT_FINAL_STAGE_STRING = "false";
 
   @Before
-  public void setUp() {
+  public void setUp() throws LoggedOutException {
     helper.setUp(); // initialize local datastore for testing
     MockitoAnnotations.initMocks(this);
     this.localDatastore = DatastoreServiceFactory.getDatastoreService();
@@ -91,7 +91,6 @@ public final class IsFinalStageTest {
     this.playerDatabase = new PlayerDatabase(localDatastore, localUserService);
     this.gameStageDatabase = new GameStageDatabase(localDatastore);
     this.isFinalStage = new IsFinalStage();
-    this.isFinalStage.init();
   }
 
   @After

--- a/src/test/java/com/google/sps/PlayerDatabaseTest.java
+++ b/src/test/java/com/google/sps/PlayerDatabaseTest.java
@@ -86,7 +86,7 @@ public final class PlayerDatabaseTest {
   private static final Gson gson = new Gson();
 
   @Before
-  public void setUp() {
+  public void setUp() throws LoggedOutException {
     helper.setUp(); // initialize local datastore for testing
     DatastoreService localDatastore = DatastoreServiceFactory.getDatastoreService();
     UserService localUserService = UserServiceFactory.getUserService();

--- a/src/test/java/com/google/sps/PromotionQuizTest.java
+++ b/src/test/java/com/google/sps/PromotionQuizTest.java
@@ -114,7 +114,7 @@ public final class PromotionQuizTest {
           + "\"isAcceptableChoice\":false}]}]";
 
   @Before
-  public void setUp() {
+  public void setUp() throws LoggedOutException {
     helper.setUp(); // initialize local datastore for testing
     MockitoAnnotations.initMocks(this);
     this.localDatastore = DatastoreServiceFactory.getDatastoreService();
@@ -122,7 +122,6 @@ public final class PromotionQuizTest {
     this.playerDatabase = new PlayerDatabase(localDatastore, localUserService);
     this.gameStageDatabase = new GameStageDatabase(localDatastore);
     this.promotionQuizServlet = this.createPromotionQuizServlet();
-    this.promotionQuizServlet.init();
   }
 
   @After

--- a/src/test/java/com/google/sps/PromotionThresholdServletTest.java
+++ b/src/test/java/com/google/sps/PromotionThresholdServletTest.java
@@ -79,12 +79,11 @@ public final class PromotionThresholdServletTest {
   @Mock private LoggedOutException e;
 
   @Before
-  public void setUp() {
+  public void setUp() throws LoggedOutException {
     helper.setUp();
     this.localUserService = UserServiceFactory.getUserService();
     this.localDatastore = DatastoreServiceFactory.getDatastoreService();
     this.promotionThresholdServlet = new PromotionThresholdServlet();
-    this.promotionThresholdServlet.init();
     this.promotionThreshold = 12;
     this.playerDatabase = new PlayerDatabase(this.localDatastore, this.localUserService);
     MockitoAnnotations.initMocks(this);

--- a/src/test/java/com/google/sps/SetGameStageTest.java
+++ b/src/test/java/com/google/sps/SetGameStageTest.java
@@ -79,14 +79,13 @@ public final class SetGameStageTest {
   private static final Gson gson = new Gson();
 
   @Before
-  public void setUp() {
+  public void setUp() throws LoggedOutException {
     // initialize local user + datastore service. Current user is admin.
     helper.setUp();
     this.localUserService = UserServiceFactory.getUserService();
     this.localDatastore = DatastoreServiceFactory.getDatastoreService();
     this.playerDatabase = new PlayerDatabase(this.localDatastore, this.localUserService);
     this.setGameStage = new SetGameStage();
-    this.setGameStage.init();
     MockitoAnnotations.initMocks(this);
   }
 


### PR DESCRIPTION
Originally, user/ datastore service was only updated upon init. This was causing some people to inherit other player's attributes. Now, upon each get/post request, the services are updated. Player state now correctly updates everytime user interacts with game
Co-authored-by: meny <mangutierrez@google.com>

Our application does seem to work exactly as expected with these changes! See here: http://cs-career-step-2020.appspot.com/ 